### PR TITLE
fix: pin CI status badge to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.org/package/automcp"><img src="https://badgen.net/npm/v/automcp" alt="npm version"/></a>
   <a href="https://www.npmjs.org/package/automcp"><img src="https://badgen.net/npm/license/automcp" alt="license"/></a>
   <a href="https://www.npmjs.org/package/automcp"><img src="https://badgen.net/npm/dt/automcp" alt="downloads"/></a>
-  <a href="https://github.com/lirantal/automcp/actions?workflow=CI"><img src="https://github.com/lirantal/automcp/workflows/CI/badge.svg?type=h" alt="build"/></a>
+  <a href="https://github.com/lirantal/automcp/actions/workflows/ci.yml"><img src="https://github.com/lirantal/automcp/actions/workflows/ci.yml/badge.svg?branch=main?type=h" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/automcp"><img src="https://badgen.net/codecov/c/github/lirantal/automcp?type=h" alt="codecov"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg?type=h" alt="Responsible Disclosure Policy" /></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.org/package/automcp"><img src="https://badgen.net/npm/v/automcp" alt="npm version"/></a>
   <a href="https://www.npmjs.org/package/automcp"><img src="https://badgen.net/npm/license/automcp" alt="license"/></a>
   <a href="https://www.npmjs.org/package/automcp"><img src="https://badgen.net/npm/dt/automcp" alt="downloads"/></a>
-  <a href="https://github.com/lirantal/automcp/actions/workflows/ci.yml"><img src="https://github.com/lirantal/automcp/actions/workflows/ci.yml/badge.svg?branch=main?type=h" alt="build"/></a>
+  <a href="https://github.com/lirantal/automcp/actions/workflows/ci.yml"><img src="https://github.com/lirantal/automcp/actions/workflows/ci.yml/badge.svg?branch=main" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/automcp"><img src="https://badgen.net/codecov/c/github/lirantal/automcp?type=h" alt="codecov"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg?type=h" alt="Responsible Disclosure Policy" /></a>
 </p>


### PR DESCRIPTION
The CI status badge in the README currently points to the unpinned workflow URL, which can show the status of any branch (e.g. PR runs) rather than the default branch. Pinning the badge to the repository default branch so it consistently reflects mainline CI.